### PR TITLE
Allow to use callables as configuration params

### DIFF
--- a/src/python/WMCore/Configuration.py
+++ b/src/python/WMCore/Configuration.py
@@ -63,6 +63,8 @@ def formatNative(value):
         return value
     if type(value) == dict:
         return dict
+    if callable(value):
+        return value
     else:
         return format(value)
 
@@ -97,7 +99,7 @@ class ConfigSection(object):
 
     def _complexTypeCheck(self, name, value):
         
-        if type(value) in _SimpleTypes:
+        if type(value) in _SimpleTypes or callable(value):
             return
         elif type(value) in _ComplexTypes:
             vallist = value


### PR DESCRIPTION
That's a very useful feature imho that exploits the true potential of having a configuration in python.

In particular I would like to have as a parameter of CRAB the function we use to pick up the schedd depending on parameters like memory usage, running jobs etc.
